### PR TITLE
Fix SSL validation toggle for ShotGrid URL check

### DIFF
--- a/services/leecher/leecher/listener.py
+++ b/services/leecher/leecher/listener.py
@@ -122,7 +122,10 @@ class ShotgridListener:
             self.log.info("SSL validation is disabled.")
 
         try:
-            validate.validate_sg_url(self.sg_url)
+            validate.validate_sg_url(
+                self.sg_url,
+                self.settings.get("shotgrid_no_ssl_validation", False),
+            )
             self.sg_session = shotgun_api3.Shotgun(
                 self.sg_url,
                 script_name=self.sg_script_name,

--- a/services/processor/processor/processor.py
+++ b/services/processor/processor/processor.py
@@ -183,7 +183,10 @@ class ShotgridProcessor:
 
         if self._sg is None:
             try:
-                validate.validate_sg_url(self.sg_url)
+                validate.validate_sg_url(
+                    self.sg_url,
+                    self.settings.get("shotgrid_no_ssl_validation", False),
+                )
                 self._sg = shotgun_api3.Shotgun(
                     self.sg_url,
                     script_name=self.sg_script_name,

--- a/services/shotgrid_common/validate.py
+++ b/services/shotgrid_common/validate.py
@@ -122,11 +122,18 @@ def _validate_project_statuses_mapping(
     return report
 
 
-def validate_sg_url(sg_url):
-    """ Ensure provided shotgrid_server URL is valid.
+def validate_sg_url(sg_url, no_ssl_validation=False):
+    """Ensure provided ShotGrid server URL is reachable.
+
+    Parameters
+    ----------
+    sg_url : str
+        The ShotGrid URL to test.
+    no_ssl_validation : bool, optional
+        When ``True`` disables SSL certificate validation for the request.
     """
     try:
-        resp = requests.get(sg_url)
+        resp = requests.get(sg_url, verify=not no_ssl_validation)
         if not resp.ok:
             raise RuntimeError(
                 f"Issue reaching {sg_url}: {resp.reason}"


### PR DESCRIPTION
## Summary
- allow disabling SSL validation in `validate_sg_url`
- pass the setting from leecher and processor when validating ShotGrid URL

## Testing
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_685949acb6cc832d804afdcf83ea11e6